### PR TITLE
Add 'beet_mysql_server' variable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+beet_mysql_server: localhost
 drupal_install_profile: standard
 drupal_enable_modules: []
 drupal_account_name: admin

--- a/tasks/install-site.yml
+++ b/tasks/install-site.yml
@@ -13,7 +13,7 @@
     --site-name="{{ beet_site_name }}"
     --account-name={{ drupal_account_name }}
     --account-pass={{ drupal_account_pass }}
-    --db-url=mysql://{{ beet_mysql_user }}:{{ beet_mysql_password }}@localhost/{{ beet_mysql_database }}
+    --db-url=mysql://{{ beet_mysql_user }}:{{ beet_mysql_password }}@{{ beet_mysql_server }}/{{ beet_mysql_database }}
     chdir={{ beet_web }}
   notify: restart webserver
   when: "'Successful' not in drupal_site_installed.stdout"


### PR DESCRIPTION
The addition of the `beet_mysql_server` variable will allow for external MySQL servers to be used, which is extremely for the use of Beetbox via Docker.
