### PR TITLE
[#5] Added support for --no-gitinfofile variable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ drupal_build_makefile: no
 drupal_makefile_path: "~/beetbox.make.yml"
 drupal_make_core_branch: "8.2.x"
 drupal_make_working_copy: "false"
+drupal_make_no_gitinfofile: yes
 drupal_distro: no
 drupal_distro_makefile: /vagrant/drupal-org.make.yml
 drupal_build_composer: no

--- a/tasks/build-makefile.yml
+++ b/tasks/build-makefile.yml
@@ -8,7 +8,7 @@
 
 - name: Generate Drupal site with drush makefile.
   command: >
-    {{ drush_path }} make -y {{ drupal_makefile_path }} --no-gitinfofile {% if drupal_distro %}--no-recursion{% endif %}
+    {{ drush_path }} make -y {{ drupal_makefile_path }} {% if drupal_make_no_gitinfofile %}--no-gitinfofile{% endif %} {% if drupal_distro %}--no-recursion{% endif %}
     chdir={{ beet_root }}
   when: not drupal_site.stat.exists
   become: no
@@ -43,7 +43,7 @@
 
 - name: Build distribution profile makefile.
   command: >
-    {{ drush_path }} make -y {{ drupal_distro_makefile }} --no-gitinfofile --no-core --contrib-destination=./
+    {{ drush_path }} make -y {{ drupal_distro_makefile }} {% if drupal_make_no_gitinfofile %}--no-gitinfofile{% endif %} --no-core --contrib-destination=./
     chdir={{ beet_root }}/profiles/{{ drupal_distro }}
   when: not drupal_site.stat.exists and drupal_distro
   become: no


### PR DESCRIPTION
`--no-gitinfofile` option for `drush make` is used to include module version information and a last version commit timestamp.

**Problem**
Currently `--no-gitinfofile` is specified by default making dependency version resolution impossible as there is no information about versions provided. As a result, drush spits out anoying messages like the one below

```
Feeds entity processor requires this module and version. Currently   [warning]
using Feeds version  (Currently using Unresolved dependency Feeds
(Version &gt;=7.x-2.0-beta1 required))
```

**Solution**
Add variable to allow optional inclusion of such CLI option. Whether to have it specified or not by default - can be discussed separately, but I personally would not want to have it specified by default as it breaks internal Drupal dependency discovery mechanisms by removing module versions.
